### PR TITLE
fix: Add missing args input for backwards compatibility

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,3 +22,4 @@ runs:
   args:
     - ${{ inputs.interval }}
     - ${{ inputs.status-checks }}
+    - ${{ inputs.args }}

--- a/action.yml
+++ b/action.yml
@@ -1,15 +1,18 @@
 name: kubectl-aws-eks
-description: "This action provides support for checking application status for fiaas applications using kubectl in Github Actions."
+description: 'This action provides support for checking application status for fiaas applications using kubectl in Github Actions.'
 author: 'Birgir Stefansson'
 inputs:
   interval:
     description: 'Time between status checks'
     required: false
-    default: 30
+    default: '30'
   status-checks:
     description: 'Number of checks before we assume failed'
     required: false
-    default: 5
+    default: '5'
+  args:
+    description: 'Application ID and potentially other arguments needed'
+    required: true
 outputs:
   status:
     description: 'The fiaas application status'


### PR DESCRIPTION
In this PR we add backwards compatibility for the `args` input. Should clear up failing status checks after #1 was merged in.