### PR TITLE
feat: Allow setting kubectl version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,11 @@ FROM alpine:latest
 
 RUN apk add py-pip curl jq && \
     pip install awscli && \
-    curl -o /usr/local/bin/aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.21.2/2021-07-05/bin/linux/amd64/aws-iam-authenticator && \
-    chmod +x /usr/local/bin/aws-iam-authenticator
+    curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl && \
+    curl -o /usr/local/bin/aws-iam-authenticator https://amazon-eks.s3.us-west-2.amazonaws.com/1.17.7/2020-07-08/bin/linux/amd64/aws-iam-authenticator && \
+    chmod +x /usr/local/bin/aws-iam-authenticator && \
+    chmod +x ./kubectl && \
+    mv ./kubectl /usr/bin/kubectl 
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 FROM alpine:latest
 
 RUN apk add py-pip curl jq && \
- pip install awscli && \
- curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl && \
- curl -o /usr/local/bin/aws-iam-authenticator https://amazon-eks.s3.us-west-2.amazonaws.com/1.17.7/2020-07-08/bin/linux/amd64/aws-iam-authenticator && \
- chmod +x /usr/local/bin/aws-iam-authenticator && \
- chmod +x ./kubectl && \
- mv ./kubectl /usr/bin/kubectl 
+    pip install awscli && \
+    curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.21.12/bin/linux/amd64/kubectl && \
+    curl -o /usr/local/bin/aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.21.2/2021-07-05/bin/linux/amd64/aws-iam-authenticator && \
+    chmod +x /usr/local/bin/aws-iam-authenticator && \
+    chmod +x ./kubectl && \
+    mv ./kubectl /usr/bin/kubectl 
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,8 @@ FROM alpine:latest
 
 RUN apk add py-pip curl jq && \
     pip install awscli && \
-    curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.21.12/bin/linux/amd64/kubectl && \
     curl -o /usr/local/bin/aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.21.2/2021-07-05/bin/linux/amd64/aws-iam-authenticator && \
-    chmod +x /usr/local/bin/aws-iam-authenticator && \
-    chmod +x ./kubectl && \
-    mv ./kubectl /usr/bin/kubectl 
+    chmod +x /usr/local/bin/aws-iam-authenticator
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,6 @@ inputs:
   kubectl_version:
     description: "Set version of kubectl"
     required: false
-    default: "1.21.12"
 outputs:
   status:
     description: "The fiaas application status"

--- a/action.yml
+++ b/action.yml
@@ -1,25 +1,30 @@
 name: kubectl-aws-eks
-description: 'This action provides support for checking application status for fiaas applications using kubectl in Github Actions.'
-author: 'Birgir Stefansson'
+description: "This action provides support for checking application status for fiaas applications using kubectl in Github Actions."
+author: "Birgir Stefansson"
 inputs:
   interval:
-    description: 'Time between status checks'
+    description: "Time between status checks"
     required: false
-    default: '30'
+    default: "30"
   status-checks:
-    description: 'Number of checks before we assume failed'
+    description: "Number of checks before we assume failed"
     required: false
-    default: '5'
+    default: "5"
   args:
-    description: 'Deployment id to check'
+    description: "Deployment id to check"
     required: true
+  kubectl_version:
+    description: "Set version of kubectl"
+    required: false
+    default: "1.21.12"
 outputs:
   status:
-    description: 'The fiaas application status'
+    description: "The fiaas application status"
 runs:
-  using: 'docker'
-  image: 'Dockerfile'
+  using: "docker"
+  image: "Dockerfile"
   args:
     - ${{ inputs.interval }}
     - ${{ inputs.status-checks }}
     - ${{ inputs.args }}
+    - ${{ inputs.kubectl_version }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,9 +12,8 @@ echo $checks
 echo $deployment_id
 echo $kubectl_version
 
-curl -LO https://storage.googleapis.com/kubernetes-release/release/${kubectl_version}/bin/linux/amd64/kubectl
-chmod +x ./kubectl && \
-    mv ./kubectl /usr/bin/kubectl 
+curl -LO https://storage.googleapis.com/kubernetes-release/release/$kubectl_version/bin/linux/amd64/kubectl
+chmod +x ./kubectl && mv ./kubectl /usr/bin/kubectl 
 
 # Extract the base64 encoded config data and write this to the KUBECONFIG
 echo "$KUBE_CONFIG_DATA" | base64 -d > /tmp/config

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -ex
+set -e
 
 interval=$1
 checks=$2
@@ -35,6 +35,7 @@ do
     return 0
   fi
   i=$((i+1))
+  echo "Not confirmed yet, trying again in $interval"
   sleep $interval
 done
 echo "::set-output name=kubectl-output::$STATUS"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,10 +5,16 @@ set -e
 interval=$1
 checks=$2
 deployment_id=$3
+kubectl_version=$4
 
 echo $interval
 echo $checks
 echo $deployment_id
+echo $kubectl_version
+
+curl -LO https://storage.googleapis.com/kubernetes-release/release/${kubectl_version}/bin/linux/amd64/kubectl
+chmod +x ./kubectl && \
+    mv ./kubectl /usr/bin/kubectl 
 
 # Extract the base64 encoded config data and write this to the KUBECONFIG
 echo "$KUBE_CONFIG_DATA" | base64 -d > /tmp/config

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,14 +6,20 @@ interval=$1
 checks=$2
 deployment_id=$3
 kubectl_version=$4
+installed_kubectl_version=$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
 
 echo $interval
 echo $checks
 echo $deployment_id
 echo $kubectl_version
 
-curl -LO https://storage.googleapis.com/kubernetes-release/release/v$kubectl_version/bin/linux/amd64/kubectl
-chmod +x ./kubectl && mv ./kubectl /usr/bin/kubectl
+if [ -n "$kubectl_version" ]; then
+  if [ $kubectl_version != $installed_kubectl_version ] then
+    echo "Installing kubectl $kubectl_version"
+    curl -LO https://storage.googleapis.com/kubernetes-release/release/$kubectl_version/bin/linux/amd64/kubectl
+    chmod +x ./kubectl && mv ./kubectl /usr/bin/kubectl
+  fi
+fi
 
 # Extract the base64 encoded config data and write this to the KUBECONFIG
 echo "$KUBE_CONFIG_DATA" | base64 -d > /tmp/config

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -e
+set -ex
 
 interval=$1
 checks=$2
@@ -12,8 +12,8 @@ echo $checks
 echo $deployment_id
 echo $kubectl_version
 
-curl -LO https://storage.googleapis.com/kubernetes-release/release/$kubectl_version/bin/linux/amd64/kubectl
-chmod +x ./kubectl && mv ./kubectl /usr/bin/kubectl 
+curl -LO https://storage.googleapis.com/kubernetes-release/release/v$kubectl_version/bin/linux/amd64/kubectl
+chmod +x ./kubectl && mv ./kubectl /usr/bin/kubectl
 
 # Extract the base64 encoded config data and write this to the KUBECONFIG
 echo "$KUBE_CONFIG_DATA" | base64 -d > /tmp/config

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,7 +14,7 @@ echo $deployment_id
 echo $kubectl_version
 
 if [ -n "$kubectl_version" ]; then
-  if [ $kubectl_version != $installed_kubectl_version ] then
+  if [ $kubectl_version != $installed_kubectl_version ]; then
     echo "Installing kubectl $kubectl_version"
     curl -LO https://storage.googleapis.com/kubernetes-release/release/$kubectl_version/bin/linux/amd64/kubectl
     chmod +x ./kubectl && mv ./kubectl /usr/bin/kubectl


### PR DESCRIPTION
Our cluster just got updated, and with it we ran into issues with `fiaas-status` which rendered the action unusable.

We got the following error:
``` error: exec plugin: invalid apiVersion "client.authentication.k8s.io/v1alpha1"````

After some debugging, we traced the error back to the kubectl version. This PR allows us to set it explicitly as a part of the parameters for the action. 

**How it works:**

1. The docker image gets the latest kubectl release
2. When action is run, check if it has kubectl_version set
3. If so, check if the version differs from the one installed
4. If it does, install the specified version.

